### PR TITLE
Redefine the taggedSum prototype constructor

### DIFF
--- a/src/daggy.js
+++ b/src/daggy.js
@@ -66,7 +66,8 @@ function tagged() {
   ```
 **/
 function taggedSum(constructors) {
-    var key;
+    var key,
+        ctor;
 
     function definitions() {
         throw new TypeError('Tagged sum was called instead of one of its properties.');
@@ -99,8 +100,10 @@ function taggedSum(constructors) {
             definitions[key] = makeProto(key);
             continue;
         }
-        definitions[key] = tagged.apply(null, constructors[key]);
+        ctor = tagged.apply(null, constructors[key]);
+        definitions[key] = ctor;
         definitions[key].prototype = makeProto(key);
+        definitions[key].prototype.constructor = ctor;
     }
 
     return definitions;

--- a/test/daggy.js
+++ b/test/daggy.js
@@ -3,6 +3,10 @@ var daggy = require('../daggy'),
         Cons: ['head', 'tail'],
         Nil: []
     }),
+    Type = daggy.taggedSum({
+        X: ['x'],
+        Y: ['y']
+    }),
     identity = function(a) {
         return a;
     },
@@ -126,4 +130,33 @@ exports.taggedSum = {
         test.equal(actual, 'nil');
         test.done();
     },
+    'when using constructor property of an instance should create a instance': function(test) {
+        var a = Math.random(),
+            x = List.Cons(a, List.Nil),
+            y = x.constructor(a, List.Nil);
+
+        test.equal(x.head, y.head);
+        test.done();
+    },
+    'when using instanceof should be Type': function(test) {
+        var a = Math.random(),
+            x = Type.X(a);
+
+        test.ok(x instanceof Type);
+        test.done();
+    },
+    'when using instanceof should be Type.X': function(test) {
+        var a = Math.random(),
+            x = Type.X(a);
+
+        test.ok(x instanceof Type.X);
+        test.done();
+    },
+    'when using instanceof should not be Type.Y': function(test) {
+        var a = Math.random(),
+            x = Type.X(a);
+
+        test.ok(!(x instanceof Type.Y));
+        test.done();
+    }
 };


### PR DESCRIPTION
- Point the taggedSum prototype constructor to the right constructor.
- Instanceof equality checks.

This allows the taggedSum instance to be created from the prototype constructor.

``` javascript
var a = List.Cons(1, List.Nil);
var b = a.constructor(2, List.Nil);
```
