### PR TITLE
Disallow null or undefined values.

### DIFF
--- a/src/daggy.js
+++ b/src/daggy.js
@@ -100,6 +100,9 @@ const makeValue = (fields, proto, values) => {
   const obj = Object.create(proto)
   defProp(obj, VALUES, values)
   for (let idx = 0; idx < fields.length; idx++) {
+    if (values[idx] === null || values[idx] === undefined) {
+      throw new TypeError(`Expected definite value for ${fields[idx]}, got ${values[idx]}`)
+    }
     obj[fields[idx]] = values[idx]
   }
   return obj

--- a/test/daggy.js
+++ b/test/daggy.js
@@ -27,6 +27,16 @@ test('tagged', (t) => {
     new TypeError(`Expected 2 arguments, got 3`),
     'when creating a tagged type with too many arguments throws error'
   )
+  t.throws(
+    () => { Tuple(1, null) },
+    new TypeError(`Expected definite value for _2`),
+    'when creating a tagged type with null argument throws error'
+  )
+  t.throws(
+    () => { Tuple(undefined, 2) },
+    new TypeError(`Expected definite value for _1`),
+    'when creating a tagged type with undefined argument throws error'
+  )
   t.same(tpl.toString(), `Tuple(${toString(a)}, ${toString(b)})`, 'toString on value should work')
   t.same(Tuple.toString(), `Tuple`, 'toString on type should work')
   t.same(tpl._1, a, 'when checking _1 value should return correct value')


### PR DESCRIPTION
I think supplying undefined or null values to the constructor should throw a type error. If a field can be null then it should be modelled with a maybe type.

This allows the constructors to play more nicely with other parsing functions.