### PR TITLE
Add .from helper to build from object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Point3D.prototype.scale = function(n){
 }
 const b = a.scale(2) // { x: 2, y: 4, z: 6 }
 b.toString() // 'Point3D(2, 4, 6)'
+const c = Point3D.from({y: 2, x: 1, z: 3}) // { x: 1, y: 2, z: 3 }
 ```
 
 ## `daggy.taggedSum(typeName, constructors)`
@@ -48,4 +49,5 @@ Option.prototype.map = function (f) {
 }
 const b = a.map(x => x+1) // { x: 2 }
 b.toString() // 'Option.Some(2)'
+const c = Option.Some.from({x: 1}) // { x: 1 }
 ```

--- a/src/daggy.js
+++ b/src/daggy.js
@@ -35,6 +35,7 @@
     typeRep.toString = typeRepToString;
     typeRep.prototype = proto;
     typeRep.is = isType;
+    typeRep.from = makeConstructorFromObject(fields, proto);
     typeRep[TYPE] = typeName;
     proto.constructor = typeRep;
     return typeRep;
@@ -62,6 +63,7 @@
       typeRep[tag][TAG] = tag;
       typeRep[tag][RET_TYPE] = typeName;
       typeRep[tag].toString = sum$ctrToString;
+      typeRep[tag].from = makeConstructorFromObject(fields, proto);
     });
     return typeRep;
   }
@@ -167,6 +169,20 @@
         {value: fields.length}
       );
     }
+  }
+
+  function makeConstructorFromObject(fields, proto) {
+    return function(obj) {
+      var values = [];
+      for (var idx = 0; idx < fields.length; idx += 1) {
+        var field = fields[idx];
+        if (!Object.prototype.hasOwnProperty.call(obj, field)) {
+          throw new TypeError('Missing field: ' + field);
+        }
+        values.push(obj[field]);
+      }
+      return makeValue(fields, proto, values, values.length);
+    };
   }
 
   return {tagged: tagged, taggedSum: taggedSum};

--- a/test/daggy.js
+++ b/test/daggy.js
@@ -36,6 +36,17 @@ test('tagged', (t) => {
   t.notOk(Tuple.is({}), '`is` on type works')
   t.same(Tuple.prototype.foo, tpl.foo, 'values in typerep.prototype are accassible from instance values')
   t.ok(Tuple.prototype.isPrototypeOf(tpl), 'prototype chain is correct')
+  t.test('build from object', (t) => {
+    const tpl = Tuple.from({_2: b, _1: a})
+    t.same(tpl._1, a, 'First value on tuple is correct')
+    t.same(tpl._2, b, 'Second value on tuple is correct')
+    t.throws(
+      () => { Tuple.from({ _1: 1 }) },
+      new TypeError('Missing field: _2'),
+      'when creating a tagged type from an object with a missing field'
+    )
+    t.end()
+  })
   t.end()
 })
 
@@ -86,5 +97,17 @@ test('taggedSum', (t) => {
   t.same(List.prototype.foo, List.Nil.foo, 'values in typerep.prototype are accassible from instance values')
   t.ok(List.prototype.isPrototypeOf(list), 'prototype chain is correct')
   t.ok(List.prototype.isPrototypeOf(List.Nil), 'prototype chain is correct')
+  t.test('build from object', (t) => {
+    const list = List.Cons.from({xs: List.Nil, x: a})
+    t.ok(List.is(list), '`is` on type works')
+    t.same(list.x, a, 'head value of list works')
+    t.same(list.xs, List.Nil, 'tail value of list works')
+    t.throws(
+      () => { List.Cons.from({x: 1}) },
+      new TypeError('Missing field: xs'),
+      'when creating a taggedSum from an object with a missing field'
+    )
+    t.end()
+  })
   t.end()
 })


### PR DESCRIPTION
This PR adds a `.from` helper to build values from a field object. This should be useful when there are many fields or you want to be more descriptive. Example:

```
const Pos = daggy.tagged("Pos", ["x", "y"]); 
const pos = Pos.from({y: 2, x: 1}); // {x: 1, y: 2}
```

This is a preliminary PR, if you like the idea we should probably add validations (i.e. throw error on missing/non-existing fields).

The function name `from` is just a proposal. IMO It should be a short name, in any case. Alternatives: `with`,  `of`.