### PR TITLE
Check all cases on cata

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -1,29 +1,31 @@
 // ┌────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬─────┐
 // │ name               │ Old                                          │ New                                          │ win │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ make.taggedSum     │ 71,315 ops/sec ±3.48% (144 runs sampled)     │ 76,830 ops/sec ±3.07% (147 runs sampled)     │ New │
+// │ make.taggedSum     │ 125,547 ops/sec ±2.88% (144 runs sampled)    │ 126,888 ops/sec ±2.95% (140 runs sampled)    │ New │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ make.tagged        │ 13,344,969 ops/sec ±0.55% (166 runs sampled) │ 573,216 ops/sec ±1.75% (153 runs sampled)    │ Old │
+// │ make.tagged        │ 903,920 ops/sec ±3.57% (153 runs sampled)    │ 889,371 ops/sec ±3.73% (152 runs sampled)    │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ make.new.taggedSum │ 47,996 ops/sec ±2.90% (151 runs sampled)     │ 49,548 ops/sec ±2.61% (153 runs sampled)     │ New │
+// │ make.new.taggedSum │ 80,258 ops/sec ±1.97% (149 runs sampled)     │ 78,150 ops/sec ±2.15% (146 runs sampled)     │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ make.new.tagged    │ 110,315 ops/sec ±3.12% (147 runs sampled)    │ 95,723 ops/sec ±2.49% (153 runs sampled)     │ Old │
+// │ make.new.tagged    │ 179,896 ops/sec ±2.60% (145 runs sampled)    │ 179,003 ops/sec ±2.21% (144 runs sampled)    │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ new.taggedSum      │ 2,165,148 ops/sec ±0.80% (170 runs sampled)  │ 2,189,430 ops/sec ±0.71% (169 runs sampled)  │ New │
+// │ new.taggedSum      │ 2,488,771 ops/sec ±0.42% (170 runs sampled)  │ 2,246,936 ops/sec ±1.91% (162 runs sampled)  │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ new.tagged         │ 2,195,517 ops/sec ±1.20% (167 runs sampled)  │ 2,307,572 ops/sec ±0.66% (170 runs sampled)  │ New │
+// │ new.tagged         │ 2,512,948 ops/sec ±0.50% (171 runs sampled)  │ 2,269,092 ops/sec ±2.42% (162 runs sampled)  │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ toString.taggedSum │ 606,363 ops/sec ±0.58% (169 runs sampled)    │ 572,571 ops/sec ±0.71% (168 runs sampled)    │ Old │
+// │ toString.taggedSum │ 1,787,871 ops/sec ±0.38% (171 runs sampled)  │ 1,717,636 ops/sec ±0.43% (170 runs sampled)  │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ toString.tagged    │ 412,286 ops/sec ±0.64% (168 runs sampled)    │ 406,783 ops/sec ±0.67% (165 runs sampled)    │ Old │
+// │ toString.tagged    │ 1,434,933 ops/sec ±0.68% (172 runs sampled)  │ 1,432,805 ops/sec ±0.28% (171 runs sampled)  │ New │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ cata               │ 25,488,200 ops/sec ±0.57% (166 runs sampled) │ 26,720,785 ops/sec ±0.39% (170 runs sampled) │ New │
+// │ cata               │ 32,679,682 ops/sec ±0.37% (171 runs sampled) │ 13,896,988 ops/sec ±0.47% (170 runs sampled) │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ instanceof.Sum     │ 16,274,027 ops/sec ±0.48% (168 runs sampled) │ 15,713,233 ops/sec ±0.39% (168 runs sampled) │ Old │
+// │ cata.giant         │ 12,877,269 ops/sec ±0.51% (170 runs sampled) │ 4,063,503 ops/sec ±0.45% (171 runs sampled)  │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ instanceof.Sum.Tag │ 13,596,912 ops/sec ±0.57% (166 runs sampled) │ 10,909,542 ops/sec ±0.35% (168 runs sampled) │ Old │
+// │ instanceof.Sum     │ 13,899,352 ops/sec ±0.48% (170 runs sampled) │ 9,174,012 ops/sec ±0.31% (172 runs sampled)  │ Old │
 // ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
-// │ instanceof.Type    │ 14,120,020 ops/sec ±0.79% (162 runs sampled) │ 14,414,014 ops/sec ±0.67% (165 runs sampled) │ New │
+// │ instanceof.Sum.Tag │ 8,666,474 ops/sec ±0.75% (168 runs sampled)  │ 8,824,885 ops/sec ±0.41% (171 runs sampled)  │ New │
+// ├────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────┤
+// │ instanceof.Type    │ 8,372,620 ops/sec ±0.49% (169 runs sampled)  │ 7,603,899 ops/sec ±0.45% (167 runs sampled)  │ Old │
 // └────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴─────┘
 require('./lib')({
   'make.taggedSum': {
@@ -61,6 +63,10 @@ require('./lib')({
   'cata': {
     Old: ({ list, pattern }) => list.cata(pattern),
     New: ({ list, pattern }) => list.cata(pattern)
+  },
+  'cata.giant': {
+    Old: ({ giant, giantPattern }) => giant.cata(giantPattern),
+    New: ({ giant, giantPattern }) => giant.cata(giantPattern)
   },
   'instanceof.Sum': {
     Old: ({ list, List }) => List.is(list),

--- a/bench/lib.js
+++ b/bench/lib.js
@@ -9,26 +9,56 @@ const ListDef = {
   Cons: ['x', 'xs'],
   Nil: []
 }
+const GiantDef = {
+  V0: [],
+  V1: ['a'],
+  V2: ['a', 'b'],
+  V3: ['a', 'b', 'c'],
+  V4: ['a', 'b', 'c', 'd'],
+  V5: ['a', 'b', 'c', 'd', 'e'],
+  V6: ['a', 'b', 'c', 'd', 'e', 'f'],
+  V7: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+  V8: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+  V9: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+}
 
 const TupleOld = daggyOld.tagged('Tuple', TupleDef)
 const ListOld = daggyOld.taggedSum('List', ListDef)
+const GiantOld = daggyOld.taggedSum('Giant', GiantDef)
 const listOld = ListOld.Cons(1, ListOld.Nil)
 const tupleOld = TupleOld(1, 2)
+const giantOld = GiantOld.V1(1)
 
 const TupleNew = daggyNew.tagged('Tuple', TupleDef)
 const ListNew = daggyNew.taggedSum('List', ListDef)
+const GiantNew = daggyNew.taggedSum('Giant', GiantDef)
 const listNew = ListNew.Cons(1, ListNew.Nil)
 const tupleNew = TupleNew(1, 2)
+const giantNew = GiantNew.V1(1)
 
 const pattern = {
   Cons: (x, xs) => 1,
   Nil: () => 0
 }
 
+const giantPattern = {
+  V0: () => 0,
+  V1: () => 1,
+  V2: () => 2,
+  V3: () => 3,
+  V4: () => 4,
+  V5: () => 5,
+  V6: () => 6,
+  V7: () => 7,
+  V8: () => 8,
+  V9: () => 9
+}
+
 const defEnv = {
   ListDef,
   TupleDef,
-  pattern
+  pattern,
+  giantPattern
 }
 const env = {
   Old: Object.assign({}, defEnv, {
@@ -37,7 +67,8 @@ const env = {
     List: ListOld,
     list: listOld,
     taggedSum: daggyOld.taggedSum,
-    tagged: daggyOld.tagged
+    tagged: daggyOld.tagged,
+    giant: giantOld
   }),
   New: Object.assign({}, defEnv, {
     tuple: tupleNew,
@@ -45,7 +76,8 @@ const env = {
     List: ListNew,
     list: listNew,
     taggedSum: daggyNew.taggedSum,
-    tagged: daggyNew.tagged
+    tagged: daggyNew.tagged,
+    giant: giantNew
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "benchmark": "2.1.3",
     "cli-table": "0.3.1",
     "colors": "1.1.2",
-    "daggy": "1.0.0",
+    "daggy": "1.3.0",
     "eslint": "3.19.x",
     "fantasy-combinators": "0.0.x",
     "sanctuary-style": "0.5.x",

--- a/test/daggy.js
+++ b/test/daggy.js
@@ -75,13 +75,23 @@ test('taggedSum', (t) => {
   )
   t.throws(
     () => { List.Nil.cata({}) },
-    new Error(`Constructors given to cata didn't include: Nil`),
+    new Error(`Constructors given to cata didn't include: Cons`),
     'throws if all cases are not handled'
   )
   t.throws(
     () => { list.cata({}) },
     new Error(`Constructors given to cata didn't include: Cons`),
     'throws if all cases are not handled'
+  )
+  t.throws(
+    () => { List.Nil.cata({ Nil: () => false }) },
+    new Error(`Constructors given to cata didn't include: Cons`),
+    'throws if some cases are not handled'
+  )
+  t.throws(
+    () => { list.cata({ Cons: () => true }) },
+    new Error(`Constructors given to cata didn't include: Nil`),
+    'throws if some cases are not handled'
   )
   t.same(list.toString(), `List.Cons(${toString(a)}, List.Nil)`, 'toString on value should work')
   t.same(List.toString(), 'List', 'toString on type should work')


### PR DESCRIPTION
Added `taggedSumChecked` which takes a `boolean` that configures it to ensure all cases are passed to `cata`.

The use case is similar to `React.propTypes`, where we do comprehensive checking of input types but only in development. For example, this would throw in development:
```
const taggedSum = taggedSumChecked(process.env.NODE_ENV !== 'production')
const Maybe = taggedSum('Maybe', { Just: ['x'], Nothing: [] })
Maybe.Just('a').cata({
  Just: () => true
})
```